### PR TITLE
Revise config option's spacer to "=".

### DIFF
--- a/src/deno_options/const.ts
+++ b/src/deno_options/const.ts
@@ -13,7 +13,7 @@ const optionsDefinitions: OptionsDefinitionsType = {
   "allow-write": { type: "string|boolean|string[]", spacer: "=" },
   "cached-only": { type: "boolean" },
   "cert": { type: "string", spacer: " " },
-  "config": { type: "string", spacer: " " },
+  "config": { type: "string", spacer: "=" },
   "importmap": { type: "string", spacer: " " },
   "inspect": { type: "string", spacer: "=" },
   "inspect-brk": { type: "string", spacer: "=" },


### PR DESCRIPTION
## Description

Replace the spacer of the '--config' option from " " space to "=" equals sign. For avoiding the parameter of --config combining with --config as a string parameter.

**Types of changes**
What types of changes does your code introduce? Keep the one that applies:
- Bugfix (non-breaking change which fixes an issue)

**Related links**
Related links section, that would have a link to issues and any other relevant information.

## Changelog

#### Fixed https://github.com/BentoumiTech/denox/issues/8

Revise `deno run --allow-net --allow-read "--config ./src/tsconfig.app.json" app.ts` to
`deno run --allow-net --allow-read --config=./src/tsconfig.app.json app.ts`
