### PR TITLE
Fix Deno 1.7.5 --isolatedModules Flag Change – Fixes #28

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,5 @@
-export { parse as parseYaml } from "https://deno.land/std@0.42.0/encoding/yaml.ts";
-export { YAMLError } from "https://deno.land/std@0.42.0/encoding/yaml/error.ts";
+export { parse as parseYaml } from "https://deno.land/std@0.88.0/encoding/yaml.ts";
+export { YAMLError } from "https://deno.land/std@0.88.0/encoding/_yaml/error.ts";
 export { red } from "https://deno.land/std@0.50.0/fmt/colors.ts";
 export { extname, resolve } from "https://deno.land/std@0.61.0/path/mod.ts";
 

--- a/src/deno_options/build_cli_arguments.ts
+++ b/src/deno_options/build_cli_arguments.ts
@@ -72,4 +72,6 @@ function _transformToArgHash(
   };
 }
 
-export { buildDenoCLIOptionsArgs, CLIArgument };
+export { buildDenoCLIOptionsArgs };
+
+export type { CLIArgument };

--- a/src/deno_options/utils.ts
+++ b/src/deno_options/utils.ts
@@ -37,4 +37,6 @@ function _typeoffNumberAsString(value: unknown): TypeOfValues {
   return typeof value;
 }
 
-export { getOptionType, OptionTypeValues };
+export { getOptionType };
+
+export type { OptionTypeValues };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -21,7 +21,7 @@ type DenoWorkspace = {
   globals?: WorkspaceGlobal;
 };
 
-export {
+export type {
   DenoWorkspace,
   WorkspaceGlobal,
   WorkspaceScript,


### PR DESCRIPTION
## Description

This pull request fixes the recently introduced `deno` incompatibility associated with the Deno project's recent change in handling of the export of types from TypeScript files so that isolated modules can be supported correctly going forward.

As of Deno version 1.5.0, the default value of the `--isolatedModules` flag is now `true`, and as of Deno version 1.7.5, support has been removed for overriding the `--isolatedModules` flag back to `false`, as such it is no longer possible to rely on the older syntax for exporting types under recent and any future versions of `deno`.

Deno as of version 1.5 (unless explicitly overridden via the `--isolatedModules` flag), and since version 1.7.5 (by default, without an option to override), now requires types to be exported using the `export types` syntax, rather than the previously supported and more general `export` syntax.

**Types of changes**

This is a Bugfix change. Running the tests that `denox` supplies, including running `denox` against the `example/` project provided within the repository, indicates that the small syntax changes needed to resolve this issue have not had any impact on the functionality of the `denox` tool.

**Related links**

- https://github.com/BentoumiTech/denox/issues/28
- https://deno.land/manual@v1.7.5/typescript/faqs#why-are-you-forcing-me-to-use-isolated-modules-why-can#39t-i-use-const-enums-with-deno-why-do-i-need-to-do-export-type

## Changelog

#### Fixed

This pull request fixes the incompatibilities between `denox` and `deno` versions 1.7.5 and above, introduced by Deno's removal of support for overriding the `--isolatedModules` flag.